### PR TITLE
feat : 카테고리 바 추가, 테마 추가, 글로벌 스타일 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router": "^6.28.0",
         "react-router-dom": "^6.28.0",
         "react-scripts": "5.0.1",
+        "sanitize.css": "^13.0.0",
         "styled-components": "^6.1.13",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-kakao-maps-sdk": "^1.1.27",
         "react-router": "^6.28.0",
         "react-router-dom": "^6.28.0",
@@ -14170,6 +14171,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "license": "MIT"
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-kakao-maps-sdk": "^1.1.27",
     "react-router": "^6.28.0",
     "react-router-dom": "^6.28.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router": "^6.28.0",
     "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
+    "sanitize.css": "^13.0.0",
     "styled-components": "^6.1.13",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,24 @@
 import './App.css';
 import SiseList from './components/SiseList';
-import Map from './components/Map';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Home from './pages/Home';
+import { ThemeProvider } from 'styled-components';
+import { theme } from './style/theme';
 
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <Map />,
+        element: <Home />,
     },
 ]);
 
 // 임시 라우팅임
 function App() {
-    return <RouterProvider router={router} />;
+    return (
+        <ThemeProvider theme={theme}>
+            <RouterProvider router={router} />
+        </ThemeProvider>
+    );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Home from './pages/Home';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './style/theme';
+import GlobalStyle from './style/global';
 
 const router = createBrowserRouter([
     {
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
 function App() {
     return (
         <ThemeProvider theme={theme}>
+            <GlobalStyle />
             <RouterProvider router={router} />
         </ThemeProvider>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const router = createBrowserRouter([
 ]);
 
 // 임시 라우팅임
+// 스타일 관련 부분은 나중에 분리 할 수도 있음
 function App() {
     return (
         <ThemeProvider theme={theme}>

--- a/src/components/CategoryBar.tsx
+++ b/src/components/CategoryBar.tsx
@@ -1,0 +1,86 @@
+import styled from 'styled-components';
+import { Link, useParams } from 'react-router-dom';
+import { FaHome } from 'react-icons/fa';
+import { HiMiniBuildingOffice } from 'react-icons/hi2';
+import { MdApartment } from 'react-icons/md';
+import { CiBookmark } from 'react-icons/ci';
+
+interface ICategory {
+    name: string;
+    value: string;
+    icon: JSX.Element;
+}
+
+const CATEGORY_LIST: ICategory[] = [
+    { name: '원/투룸', value: 'dasedae', icon: <FaHome /> },
+    { name: '오피스텔', value: 'officetel', icon: <HiMiniBuildingOffice /> },
+    { name: '아파트', value: 'apt', icon: <MdApartment /> },
+    { name: '북마크', value: 'bookmark', icon: <CiBookmark /> },
+];
+
+const CategoryBar = () => {
+    // const { category } = useParams<{ category: string }>();
+    // TODO : useParam을 이용해서 현재 선택된 카테고리를 표시
+    return (
+        <StyledCategoryBar>
+            <ul>
+                {CATEGORY_LIST.map((category) => {
+                    return (
+                        <li key={category.value}>
+                            <Link to={`/${category.value}`}>
+                                {category.icon}
+                                <span>{category.name}</span>
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+        </StyledCategoryBar>
+    );
+};
+
+const StyledCategoryBar = styled.nav`
+    display: flex;
+    flex-direction: column;
+    width: 5rem;
+    min-height: 100vh;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+
+    ul {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+
+        li {
+            a {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                width: 4.5rem;
+                height: 4.5rem;
+                border-radius: ${({ theme }) => theme.borderRadius.default};
+                gap: 0.25rem;
+                color: #4b5563;
+                transition: color 0.3s ease;
+                font-weight: 700;
+                font-size: 1.5rem;
+
+                &:hover {
+                    color: #3b82f6;
+                    font-weight: 800;
+                    background-color: rgb(237, 237, 237);
+                }
+
+                span {
+                    font-size: 0.75rem;
+                    text-align: center;
+                }
+            }
+        }
+    }
+`;
+
+export default CategoryBar;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import Map from '../components/Map';
+import CategoryBar from '../components/CategoryBar';
+
+// 임시 페이지입니다.
+const Home = () => {
+    return (
+        <StyledHome>
+            <CategoryBar />
+            <Map />
+        </StyledHome>
+    );
+};
+
+const StyledHome = styled.main`
+    display: flex;
+    height: 100vh;
+`;
+
+export default Home;

--- a/src/style/global.ts
+++ b/src/style/global.ts
@@ -1,0 +1,17 @@
+import 'sanitize.css';
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+    body {
+        padding: 0;
+        margin: 0;
+
+    }
+
+    h1 {
+        margin: 0;
+    }
+
+`;
+
+export default GlobalStyle;

--- a/src/style/global.ts
+++ b/src/style/global.ts
@@ -11,7 +11,15 @@ const GlobalStyle = createGlobalStyle`
     h1 {
         margin: 0;
     }
+    
+    a{
+        text-decoration: none;
+        color: #3B4856;
+    }
 
+    a:visited {
+        color: #3B4856;
+    }
 `;
 
 export default GlobalStyle;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,4 +1,4 @@
-export type Colorkey =
+type Colorkey =
     | 'primary'
     | 'secondary'
     | 'third'
@@ -7,8 +7,8 @@ export type Colorkey =
     | 'neutral-background'
     | 'dark-background'
     | 'text';
-export type HeadingSize = 'large' | 'medium' | 'small';
-export type LayoutWidth = 'small' | 'medium' | 'large';
+type HeadingSize = 'large' | 'medium' | 'small';
+type LayoutWidth = 'small' | 'medium' | 'large';
 
 interface Theme {
     name: string;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -3,9 +3,9 @@ type Colorkey =
     | 'secondary'
     | 'third'
     | 'forth'
-    | 'light-background'
-    | 'neutral-background'
-    | 'dark-background'
+    | 'lightBackground'
+    | 'neutralBackground'
+    | 'darkBackground'
     | 'text';
 type HeadingSize = 'large' | 'medium' | 'small';
 type LayoutWidth = 'small' | 'medium' | 'large';
@@ -35,9 +35,9 @@ export const theme: Theme = {
         secondary: '#6B95BC',
         third: '#D5A667',
         forth: '#9C7236',
-        'light-background': '#F2FAFF',
-        'neutral-background': '#9FADBD',
-        'dark-background': '#3B4856',
+        lightBackground: '#F2FAFF',
+        neutralBackground: '#9FADBD',
+        darkBackground: '#3B4856',
         text: '#3B4856',
     },
     heading: {

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,0 +1,64 @@
+export type Colorkey =
+    | 'primary'
+    | 'secondary'
+    | 'third'
+    | 'forth'
+    | 'light-background'
+    | 'neutral-background'
+    | 'dark-background'
+    | 'text';
+export type HeadingSize = 'large' | 'medium' | 'small';
+export type LayoutWidth = 'small' | 'medium' | 'large';
+
+interface Theme {
+    name: string;
+    colors: Record<Colorkey, string>;
+    heading: {
+        [key in HeadingSize]: {
+            fontSize: string;
+        };
+    };
+    borderRadius: {
+        default: string;
+    };
+    layout: {
+        width: {
+            [key in LayoutWidth]: string;
+        };
+    };
+}
+
+export const theme: Theme = {
+    name: 'main',
+    colors: {
+        primary: '#64B5F6',
+        secondary: '#6B95BC',
+        third: '#D5A667',
+        forth: '#9C7236',
+        'light-background': '#F2FAFF',
+        'neutral-background': '#9FADBD',
+        'dark-background': '#3B4856',
+        text: '#3B4856',
+    },
+    heading: {
+        large: {
+            fontSize: '2rem',
+        },
+        medium: {
+            fontSize: '1.5rem',
+        },
+        small: {
+            fontSize: '1rem',
+        },
+    },
+    borderRadius: {
+        default: '4px',
+    },
+    layout: {
+        width: {
+            small: '320px',
+            medium: '760px',
+            large: '1020px',
+        },
+    },
+};


### PR DESCRIPTION
# 🔍 PR 개요

feat : 카테고리 바 추가, 테마 추가, 글로벌 스타일 적용

## 📝 작업 내용

<!-- 구현한 기능에 대해 자세히 작성해주세요 -->

-   [x] 사이드바 레이아웃에 사용할 카테코리 메뉴 컴포넌트 구현
-   [x] 기본색깔을 포함한 styled component 테마 적용
-   [x] normalize.css와 기본 설정 글로벌 스타일 적용

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

-   Closes #이슈번호
-   Related to #이슈번호

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="469" alt="스크린샷 2024-11-20 오후 6 09 56" src="https://github.com/user-attachments/assets/421b2789-db46-4c30-9654-d5a7e14ae2be">

호버 하면 회색 바탕


## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

-   [x] 수동 테스트 완료
-   [ ] 불필요한 코드 없음 (console.log, 주석 등)
-   [x] 명확한 커밋 메세지
-   [ ] 충분한 문서화

## 🔄 공유할 사항

- theme과 글로벌 스타일에 필요한 속성이 있으시면 마음 껏 추가해주세요.
- url 어떻게 할지 논의 해봐야 할듯 카테고리를 아래처럼 param으로 하는게 좋아보임
- 카테고리 목록은 일단 임시로 넣어봄
- 현재 북마크도 여기서 들어오므로 그 경우도 생각해야함
daebang.com/oneroom/?region={구코드} 

searchParam으로 하는 경우도 가능하나 restful하지 않은 듯
daebang.com/?category={카테고리}&region={구코드} 

## TODO
레이아웃 잡은 뒤 현재 param에 따라 선택된 카테고리를 강조하는 기능을 추가하겠습니다.
<img width="81" alt="스크린샷 2024-11-20 오후 6 14 19" src="https://github.com/user-attachments/assets/643dc2bd-823e-4454-ab19-16f8f2fef92e">
