### PR TITLE
fix : 카테고리 변경시 데이터 안불러와지는 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import { theme } from './style/theme';
 import GlobalStyle from './style/global';
 import Layout from './components/Layout';
 import { Routes, Route, BrowserRouter as Router } from 'react-router-dom';
-
 import SiseList from './components/Sise/SiseList';
+
 function App() {
     return (
         <ThemeProvider theme={theme}>

--- a/src/components/CategoryBar.tsx
+++ b/src/components/CategoryBar.tsx
@@ -5,6 +5,7 @@ import { HiMiniBuildingOffice } from 'react-icons/hi2';
 import { MdApartment } from 'react-icons/md';
 import { CiBookmark } from 'react-icons/ci';
 import { useSise } from '../hooks/useSise';
+import { useLocation } from 'react-router-dom';
 
 interface ICategory {
     name: string;
@@ -22,6 +23,7 @@ const CATEGORY_LIST: ICategory[] = [
 const CategoryBar = () => {
     const { category } = useParams<{ category: string }>();
     const { regionCode } = useSise();
+    const location = useLocation();
 
     console.log(category);
 
@@ -32,7 +34,10 @@ const CategoryBar = () => {
                     return (
                         <li key={item.value}>
                             <StyledLink
-                                to={`/${item.value}`}
+                                to={{
+                                    pathname: `/${item.value}`,
+                                    search: location.search,
+                                }}
                                 state={{ regionCode }}
                                 $isActive={item.value === category}
                             >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Outlet } from 'react-router';
 
 const Sidebar = () => {
-    const [isOpen, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     const toggleSidebar = () => {
         setIsOpen(!isOpen);


### PR DESCRIPTION
# 🔍 PR 개요

fix : 카테고리 변경시 데이터 안불러와지는 오류 수정

<img width="457" alt="스크린샷 2024-11-22 오전 12 31 05" src="https://github.com/user-attachments/assets/5b020571-25e7-4d84-a6b7-18cfbe56cedb">


## 📝 작업 내용


-   [x] 카테고리 링크에 서치파람도 전달하게 수정
-   [x] 사이드바 기본상태 열림으로 변경


## 📸 스크린샷

전
<img width="295" alt="스크린샷 2024-11-22 오전 12 28 28" src="https://github.com/user-attachments/assets/16a08af2-8986-4fc8-acf3-4228c9af95c7">
후
<img width="351" alt="스크린샷 2024-11-22 오전 12 28 30" src="https://github.com/user-attachments/assets/77922340-12c9-4cd3-bd1c-3ac2e526b3a8">


## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

-   [x] 수동 테스트 완료
-   [x] 불필요한 코드 없음 (console.log, 주석 등)
-   [x] 명확한 커밋 메세지
-   [ ] 충분한 문서화


