### PR TITLE
feat : 시세 불러와서 주소별로 묶고 좌표추가하기

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,10 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
         <title>React App</title>
+        <script
+            type="text/javascript"
+            src="//dapi.kakao.com/v2/maps/sdk.js?appkey=0be8ca05ad0dd0c80da443e49e5f1488&libraries=services,clusterer"
+        ></script>
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -37,6 +37,18 @@ const Map = () => {
     const { data, isPending, isError, error } = useSiseWithReactQuery();
     console.log(data, isPending, isError, error);
 
+    // 기존에는 첫 진입시 서치파람이 없는 문제가 있었는데, 일단은 하드코딩해서 해결했습니다.
+    useEffect(() => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        if (!newSearchParams.has('region')) {
+            newSearchParams.set('region', '11140');
+            setSearchParams(newSearchParams);
+        }
+        if (!address) {
+            setAddress('서울특별시 중구 ');
+        }
+    }, []);
+
     // 지도 드래그가 끝날 때 마다 중심좌표를 가져오고 주소를 검색합니다.
     // 검색된 주소의 법정동 코드 앞 5자리(구코드)를 URLSearchParams에 추가합니다.
     // TODO: 후에 custom hook으로 분리할 수도 있음.

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -19,10 +19,10 @@ interface Position {
 
 const Map = () => {
     // 해당 hook를 사용이후 전역에 설치가 되고 이후 재호출(동일한 옵션)이 일어나더라도 재설치 되거나, 제거되지 않습니다.
-    useKakaoLoader({
-        appkey: '0be8ca05ad0dd0c80da443e49e5f1488',
-        libraries: ['clusterer', 'drawing', 'services'],
-    });
+    // useKakaoLoader({
+    //     appkey: '0be8ca05ad0dd0c80da443e49e5f1488',
+    //     libraries: ['clusterer', 'drawing', 'services'],
+    // });
 
     const [searchParams, setSearchParams] = useSearchParams();
     const mapRef = useRef<kakao.maps.Map>(null);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -4,9 +4,10 @@ import {
     ZoomControl,
     MapMarker,
 } from 'react-kakao-maps-sdk';
-import useKakaoLoader from '../hooks/useKaKaoLoader';
-import { useRef, useCallback, useState } from 'react';
-import { debounce } from 'lodash';
+// import useKakaoLoader from '../hooks/useKaKaoLoader';
+import { useKakaoLoader } from 'react-kakao-maps-sdk';
+import { useRef, useCallback, useState, useEffect } from 'react';
+import { debounce, set } from 'lodash';
 import { useSearchParams } from 'react-router-dom';
 import LocationPopup from './Map/LocationPopup';
 import useSiseWithReactQuery from '../hooks/useSiseWithReactQuery';
@@ -17,7 +18,11 @@ interface Position {
 }
 
 const Map = () => {
-    useKakaoLoader();
+    // 해당 hook를 사용이후 전역에 설치가 되고 이후 재호출(동일한 옵션)이 일어나더라도 재설치 되거나, 제거되지 않습니다.
+    useKakaoLoader({
+        appkey: '0be8ca05ad0dd0c80da443e49e5f1488',
+        libraries: ['clusterer', 'drawing', 'services'],
+    });
 
     const [searchParams, setSearchParams] = useSearchParams();
     const mapRef = useRef<kakao.maps.Map>(null);
@@ -38,42 +43,34 @@ const Map = () => {
     const handleCenterChanged = useCallback(
         debounce(() => {
             const map = mapRef.current;
-            if (map) {
-                const center = map.getCenter();
-
-                searchAddrFromCoords(
-                    { lat: center.getLat(), lng: center.getLng() },
-                    (result, status) => {
-                        if (status === kakao.maps.services.Status.OK) {
-                            setAddress(result[0].address_name);
-                            const code = result[0].code
-                                .toString()
-                                .substring(0, 5);
-                            const newSearchParams = new URLSearchParams(
-                                searchParams,
-                            );
-
-                            newSearchParams.set('region', code);
-                            setSearchParams(newSearchParams);
-                        } else {
-                            console.log('주소 정보를 가져오지 못했습니다.');
-                        }
-                    },
-                );
-            }
+            if (!map) return;
+            const center = map.getCenter();
+            setCenter({ lat: center.getLat(), lng: center.getLng() });
+            searchAddressFromCoordsAndSetSearchParam({
+                lat: center.getLat(),
+                lng: center.getLng(),
+            });
         }, 200),
         [searchParams, setSearchParams],
     );
 
-    // 좌표로 행정동 주소 정보를 요청합니다.
-    // TODO : any 타입 대신 명확한 타입을 정의.
-    const searchAddrFromCoords = (
-        position: Position,
-        callback: (result: any, status: any) => void,
-    ) => {
+    const searchAddressFromCoordsAndSetSearchParam = (position: Position) => {
         // 좌표로 행정동 주소 정보를 요청합니다
         const geocoder = new kakao.maps.services.Geocoder();
-        geocoder.coord2RegionCode(position.lng, position.lat, callback);
+        geocoder.coord2RegionCode(
+            position.lng,
+            position.lat,
+            (result, status) => {
+                if (status === kakao.maps.services.Status.OK) {
+                    const address = result[0].address_name;
+                    const code = result[0].code.toString().substring(0, 5);
+                    setAddress(address);
+                    const newSearchParams = new URLSearchParams(searchParams);
+                    newSearchParams.set('region', code);
+                    setSearchParams(newSearchParams);
+                }
+            },
+        );
     };
 
     //TODO : 마커정보를 받아와 동적으로 마커를 표시합니다.

--- a/src/hooks/useSiseWithReactQuery.ts
+++ b/src/hooks/useSiseWithReactQuery.ts
@@ -2,6 +2,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSiseDataThatThrowsError } from '../api/Sise.api';
 import { groupSiseByAddress } from '../utils/sortUtils';
+import { addXyToSiseOfBuilding } from '../utils/adress';
 
 // 이 훅을 사용하면 앱에서 데이터를 쉽게 공유할 수 있습니다.
 const useSiseWithReactQuery = () => {
@@ -14,20 +15,21 @@ const useSiseWithReactQuery = () => {
     const { data, isPending, isError, error } = useQuery({
         queryKey: ['siseData', regionCode],
         queryFn: async () => {
-            return await fetchSiseDataThatThrowsError({
+            const data = await fetchSiseDataThatThrowsError({
                 LAWD_CD: regionCode,
                 DEAL_YMD: Number(currentYYYYMM),
                 pageNo: 1,
                 numOfRows: 1000,
             });
-        },
-        select: (data) => {
+
             let item = data.response.body.items.item;
 
             if (!Array.isArray(item)) {
                 item = [item];
             }
             const groupedByAdressItems = groupSiseByAddress(item);
+
+            return await addXyToSiseOfBuilding(groupedByAdressItems);
         },
     });
 

--- a/src/hooks/useSiseWithReactQuery.ts
+++ b/src/hooks/useSiseWithReactQuery.ts
@@ -1,6 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSiseDataThatThrowsError } from '../api/Sise.api';
+import { groupSiseByAddress } from '../utils/sortUtils';
 
 // 이 훅을 사용하면 앱에서 데이터를 쉽게 공유할 수 있습니다.
 const useSiseWithReactQuery = () => {
@@ -20,8 +21,14 @@ const useSiseWithReactQuery = () => {
                 numOfRows: 1000,
             });
         },
-        select: (data) => data.response.body.items,
-        // slect에서 data를 가공할 수 있습니다.
+        select: (data) => {
+            let item = data.response.body.items.item;
+
+            if (!Array.isArray(item)) {
+                item = [item];
+            }
+            const groupedByAdressItems = groupSiseByAddress(item);
+        },
     });
 
     return { data, isPending, isError, error };

--- a/src/models/Sise.model.ts
+++ b/src/models/Sise.model.ts
@@ -40,3 +40,29 @@ export interface paginateByKeyResultProps {
     index: number;
     data: { key: string; items: Sise[] }[];
 }
+
+export interface SiseOfBuilding {
+    buildYear: number;
+    huseType: string;
+    jibun: number;
+    mhouseNm: string;
+    sggCd: number;
+    umdNum: string;
+    contracts: Contract[];
+}
+
+// 같은 지번이라도 면적이 다를 수 있어서 빼봤습니다.
+export interface Contract {
+    contractTerm: string;
+    contractType: string;
+    dealDay: number;
+    dealMonth: number;
+    dealYear: number;
+    deposit: string;
+    excluUseAr: number;
+    floor: number;
+    monthlyRent: number;
+    preDeposit: string;
+    preMonthyRent: number;
+    useRRRight: string;
+}

--- a/src/models/Sise.model.ts
+++ b/src/models/Sise.model.ts
@@ -66,3 +66,8 @@ export interface Contract {
     preMonthyRent: number;
     useRRRight: string;
 }
+
+export interface SiseOfBuildingWithXy extends SiseOfBuilding {
+    x: number;
+    y: number;
+}

--- a/src/utils/adress.ts
+++ b/src/utils/adress.ts
@@ -1,0 +1,45 @@
+import { SiseOfBuilding, SiseOfBuildingWithXy } from '../models/Sise.model';
+
+export const addXyToSiseOfBuilding = async (
+    buildings: SiseOfBuilding[],
+): Promise<SiseOfBuildingWithXy[]> => {
+    const promises = buildings.map(async (building) => {
+        const query = `${building.umdNum} ${building.jibun}`;
+
+        try {
+            const { x, y } = await getXyFromAddress(query);
+            return {
+                ...building,
+                x,
+                y,
+            };
+        } catch (error) {
+            console.error('좌표 가져오기 실패:', error);
+            return {
+                ...building,
+                x: 0,
+                y: 0,
+            };
+        }
+    });
+
+    return await Promise.all(promises);
+};
+
+export const getXyFromAddress = (
+    address: string,
+): Promise<{ x: number; y: number }> => {
+    return new Promise((resolve, reject) => {
+        const geocoder = new kakao.maps.services.Geocoder();
+
+        geocoder.addressSearch(address, (result, status) => {
+            if (status === kakao.maps.services.Status.OK && result[0]) {
+                const x = parseFloat(result[0].x);
+                const y = parseFloat(result[0].y);
+                resolve({ x, y });
+            } else {
+                reject('좌표를 가져올 수 없습니다.');
+            }
+        });
+    });
+};

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -1,4 +1,9 @@
-import { paginateByKeyResultProps, Sise } from '../models/Sise.model';
+import {
+    paginateByKeyResultProps,
+    Sise,
+    SiseOfBuilding,
+    Contract,
+} from '../models/Sise.model';
 
 export const groupAndSortByDate = (
     data: Sise[],
@@ -39,4 +44,42 @@ export const paginateByKey = (
     }
 
     return paginatedData;
+};
+
+export const groupSiseByAddress = (data: Sise[]): SiseOfBuilding[] => {
+    const buildingMap: { [key: string]: SiseOfBuilding } = {};
+
+    data.forEach((item) => {
+        const key = `${item.umdNm} ${item.jibun}`;
+        if (!buildingMap[key]) {
+            buildingMap[key] = {
+                buildYear: item.buildYear,
+                huseType: item.houseType,
+                jibun: item.jibun,
+                mhouseNm: item.mhouseNm,
+                sggCd: item.sggCd,
+                umdNum: item.umdNm,
+                contracts: [],
+            };
+        }
+
+        const contract: Contract = {
+            contractTerm: item.contractTerm,
+            contractType: item.contractType,
+            dealDay: item.dealDay,
+            dealMonth: item.dealMonth,
+            dealYear: item.dealYear,
+            deposit: item.deposit,
+            excluUseAr: item.excluUseAr,
+            floor: item.floor,
+            monthlyRent: item.monthlyRent,
+            preDeposit: item.preDeposit,
+            preMonthyRent: item.preMonthyRent,
+            useRRRight: item.useRRRight,
+        };
+
+        buildingMap[key].contracts.push(contract);
+    });
+
+    return Object.values(buildingMap);
 };


### PR DESCRIPTION
# 🔍 PR 개요

useSiseWithReactQuery을 통해 주소별로 묶어지고 좌표가 추가된 데이터를 받을 수 있습니다.

## 📝 작업 내용

-   [x] 시세 배열을 받아 같으 주소끼리 묶는 유틸 함수 추가
-   [x] 주소를 받아 좌표를 가져오는 유틸 함수
-   [x] 주소에 좌표 추가하기

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

-   Closes #이슈번호
-   Related to #이슈번호

## 📸 스크린샷

<img width="528" alt="스크린샷 2024-11-23 오후 10 19 45" src="https://github.com/user-attachments/assets/e6a2bd7b-9deb-4770-9d5b-23a6b936aa89">


## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

-   [x] 수동 테스트 완료
-   [x] 불필요한 코드 없음 (console.log, 주석 등)
-   [x] 명확한 커밋 메세지
-   [x] 충분한 문서화

## 🔄 공유할 사항

데이터 타입을 sise.model.ts에 정의해 두었음.

현재 맵에서 데이터를 받아서 콘솔로 찍고 있기 때문에 이를 참고 해도 좋음

이제 시세리스트에서 이 데이터를 받아 적용하고
맵에서는 마커를 표시해주면 됨

한계점 : 아직 1개월치(현재월로 고정)만 받아오는 걸로 해봄 근데 데이터양이 부족하진 않긴함 

카카오 주소찾기 Rest API를 사용하려 했으나 이거는  too many request 오류가 나서 geocoder.addressSearch()을 사용함
이거는 응답제한이 없는듯
