### PR TITLE
feat : 맵에 마커 표시

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -27,16 +27,9 @@ const Map = () => {
     const { data, isPending, isError, error } = useSiseWithReactQuery();
     console.log(data, isPending, isError, error);
 
-    // 기존에는 첫 진입시 서치파람이 없는 문제가 있었는데, 일단은 하드코딩해서 해결했습니다.
+    // 첫 로드시 중심좌표로 주소를 검색하여 구코드를 URLSearchParams에 추가합니다.
     useEffect(() => {
-        const newSearchParams = new URLSearchParams(searchParams);
-        if (!newSearchParams.has('region')) {
-            newSearchParams.set('region', '11140');
-            setSearchParams(newSearchParams);
-        }
-        if (!address) {
-            setAddress('서울특별시 중구 ');
-        }
+        searchAddressFromCoordsAndSetSearchParam(center);
     }, []);
 
     // 지도 드래그가 끝날 때 마다 중심좌표를 가져오고 주소를 검색합니다.

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -5,7 +5,7 @@ import {
     MapMarker,
 } from 'react-kakao-maps-sdk';
 import { useRef, useCallback, useState, useEffect } from 'react';
-import { debounce, set } from 'lodash';
+import { debounce } from 'lodash';
 import { useSearchParams } from 'react-router-dom';
 import LocationPopup from './Map/LocationPopup';
 import useSiseWithReactQuery from '../hooks/useSiseWithReactQuery';
@@ -16,7 +16,6 @@ interface Position {
 }
 
 const Map = () => {
-
     const [searchParams, setSearchParams] = useSearchParams();
     const mapRef = useRef<kakao.maps.Map>(null);
     const [center, setCenter] = useState<Position>({

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -5,11 +5,11 @@ import {
     CustomOverlayMap,
 } from 'react-kakao-maps-sdk';
 import { useRef, useCallback, useState, useEffect } from 'react';
-import { debounce } from 'lodash';
+import { debounce, set } from 'lodash';
 import { useSearchParams } from 'react-router-dom';
 import LocationPopup from './Map/LocationPopup';
 import useSiseWithReactQuery from '../hooks/useSiseWithReactQuery';
-import { MAP_CENTER_POSITION } from '../utils/constants';
+import { MAP_CENTER_POSITION, MAP_ZOOM_LEVEL } from '../utils/constants';
 import CustomMapMarker from './Map/CustomMapMarker';
 
 export interface Position {
@@ -22,7 +22,7 @@ const Map = () => {
     const mapRef = useRef<kakao.maps.Map>(null);
     const [center, setCenter] = useState<Position>(MAP_CENTER_POSITION);
     const [address, setAddress] = useState<string>('');
-    const [markers, setMarkers] = useState([]);
+    const [zoom, setZoom] = useState<number>(MAP_ZOOM_LEVEL);
     const { data, isPending, isError, error } = useSiseWithReactQuery();
     console.log(data, isPending, isError, error);
 
@@ -74,10 +74,12 @@ const Map = () => {
             <KakaoMap
                 id="map"
                 center={center}
-                level={7}
+                level={zoom}
+                onZoomChanged={(target) => setZoom(target.getLevel())}
                 keyboardShortcuts={true}
                 onCenterChanged={handleCenterChanged}
                 // TODO : 임시 스타일링 입니다. 후에 width, height 100%로 변경해주세요.
+
                 style={{
                     display: 'flex',
                     width: '100%',
@@ -90,6 +92,7 @@ const Map = () => {
                 <MapTypeControl position={'TOPRIGHT'} />
                 <ZoomControl position={'BOTTOMRIGHT'} />
                 {data &&
+                    zoom <= 7 &&
                     data.map((item) => {
                         return (
                             <CustomOverlayMap

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -4,8 +4,6 @@ import {
     ZoomControl,
     MapMarker,
 } from 'react-kakao-maps-sdk';
-// import useKakaoLoader from '../hooks/useKaKaoLoader';
-import { useKakaoLoader } from 'react-kakao-maps-sdk';
 import { useRef, useCallback, useState, useEffect } from 'react';
 import { debounce, set } from 'lodash';
 import { useSearchParams } from 'react-router-dom';
@@ -18,11 +16,6 @@ interface Position {
 }
 
 const Map = () => {
-    // 해당 hook를 사용이후 전역에 설치가 되고 이후 재호출(동일한 옵션)이 일어나더라도 재설치 되거나, 제거되지 않습니다.
-    // useKakaoLoader({
-    //     appkey: '0be8ca05ad0dd0c80da443e49e5f1488',
-    //     libraries: ['clusterer', 'drawing', 'services'],
-    // });
 
     const [searchParams, setSearchParams] = useSearchParams();
     const mapRef = useRef<kakao.maps.Map>(null);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -9,8 +9,9 @@ import { debounce } from 'lodash';
 import { useSearchParams } from 'react-router-dom';
 import LocationPopup from './Map/LocationPopup';
 import useSiseWithReactQuery from '../hooks/useSiseWithReactQuery';
+import { MAP_CENTER_POSITION } from '../utils/constants';
 
-interface Position {
+export interface Position {
     lat: number;
     lng: number;
 }
@@ -18,10 +19,7 @@ interface Position {
 const Map = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const mapRef = useRef<kakao.maps.Map>(null);
-    const [center, setCenter] = useState<Position>({
-        lat: 37.5642135,
-        lng: 127.0016985,
-    });
+    const [center, setCenter] = useState<Position>(MAP_CENTER_POSITION);
     const [address, setAddress] = useState<string>('');
     const [markers, setMarkers] = useState([
         { lat: 33.450701, lng: 126.570667 },

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -2,7 +2,7 @@ import {
     Map as KakaoMap,
     MapTypeControl,
     ZoomControl,
-    MapMarker,
+    CustomOverlayMap,
 } from 'react-kakao-maps-sdk';
 import { useRef, useCallback, useState, useEffect } from 'react';
 import { debounce } from 'lodash';
@@ -10,6 +10,7 @@ import { useSearchParams } from 'react-router-dom';
 import LocationPopup from './Map/LocationPopup';
 import useSiseWithReactQuery from '../hooks/useSiseWithReactQuery';
 import { MAP_CENTER_POSITION } from '../utils/constants';
+import CustomMapMarker from './Map/CustomMapMarker';
 
 export interface Position {
     lat: number;
@@ -21,9 +22,7 @@ const Map = () => {
     const mapRef = useRef<kakao.maps.Map>(null);
     const [center, setCenter] = useState<Position>(MAP_CENTER_POSITION);
     const [address, setAddress] = useState<string>('');
-    const [markers, setMarkers] = useState([
-        { lat: 33.450701, lng: 126.570667 },
-    ]);
+    const [markers, setMarkers] = useState([]);
     const { data, isPending, isError, error } = useSiseWithReactQuery();
     console.log(data, isPending, isError, error);
 
@@ -68,9 +67,7 @@ const Map = () => {
         );
     };
 
-    //TODO : 마커정보를 받아와 동적으로 마커를 표시합니다.
-    //TODO : 마커를 클릭시 해당 마커의 정보를 표시합니다.
-    //TODO : 마커정보는 상태로 관리하지만 Props로 받아올 수도 있습니다.
+    //TODO : 일정 zoom level부터 마커를 표시합니다.
 
     return (
         <>
@@ -92,16 +89,17 @@ const Map = () => {
             >
                 <MapTypeControl position={'TOPRIGHT'} />
                 <ZoomControl position={'BOTTOMRIGHT'} />
-                {markers.map((marker, index) => (
-                    <MapMarker
-                        key={index}
-                        position={{ lat: marker.lat, lng: marker.lng }}
-                        onClick={() => {
-                            console.log('마커 클릭됨');
-                        }}
-                    />
-                ))}
-
+                {data &&
+                    data.map((item) => {
+                        return (
+                            <CustomOverlayMap
+                                key={`${item.umdNum} ${item.jibun} ${item.mhouseNm}`}
+                                position={{ lat: item.y, lng: item.x }}
+                            >
+                                <CustomMapMarker sise={item} />
+                            </CustomOverlayMap>
+                        );
+                    })}
                 <LocationPopup address={address} />
             </KakaoMap>
         </>

--- a/src/components/Map/CustomMapMarker.tsx
+++ b/src/components/Map/CustomMapMarker.tsx
@@ -1,0 +1,128 @@
+import styled from 'styled-components';
+import { SiseOfBuildingWithXy } from '../../models/Sise.model';
+
+interface CustomMapMarkerProps {
+    sise: SiseOfBuildingWithXy;
+}
+
+const CustomMapMarker = ({ sise }: CustomMapMarkerProps) => {
+    // TODO : 현재는 첫번째 계약 정보를 보여주고 있으나, 추후에 평균계약 정보를 조여주면 좋을 것 같음.
+    // 이는 전세 월세  필터가 생긴다음 구현하는게 좋을 것 같음.
+
+    // TODO : 말풀선으 꼬리로 좌표를 가리키기 위해 마커의 위치를 조정하고 있는데 완벽하지 않음..
+
+    //TODO : 마커 클릭시 상세 정보를 보여주어야 함.
+    const contractType = sise.contracts[0].monthlyRent ? '월세' : '전세';
+    return (
+        <StyledCustomMapMarker
+            onClick={() => {
+                console.log(sise);
+            }}
+        >
+            <div className="container">
+                <div className="marker">
+                    <span>{contractType}</span>
+                    {contractType === '전세' && (
+                        <span>{sise.contracts[0].deposit}</span>
+                    )}
+                    {contractType === '월세' && (
+                        <span>
+                            {sise.contracts[0].deposit}/
+                            {sise.contracts[0].monthlyRent}
+                        </span>
+                    )}
+                </div>
+                <div className="pop-up">
+                    <div>
+                        {sise.umdNum} {sise.jibun} {sise.mhouseNm}
+                    </div>
+                    {sise.contracts.map((contract, index) => (
+                        <div key={index}>
+                            {contract.contractType} {contract.deposit}/
+                            {contract.monthlyRent}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </StyledCustomMapMarker>
+    );
+};
+
+const StyledCustomMapMarker = styled.div`
+    .container {
+        position: relative;
+        width: fit-content;
+        cursor: pointer;
+        transform: translate(30%, -60%);
+
+        .marker {
+            background: #3b82f6;
+            color: white;
+            padding: 8px 12px;
+            border-radius: 3px;
+            font-size: 14px;
+            position: relative;
+            white-space: nowrap;
+            box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+            transition:
+                opacity 0.2s,
+                visibility 0.2s;
+
+            &::after {
+                content: '';
+                position: absolute;
+                bottom: -8px;
+                left: 18px;
+                width: 0;
+                height: 0;
+                border-left: 8px solid transparent;
+                border-right: 8px solid transparent;
+                border-top: 8px solid #3b82f6;
+            }
+        }
+
+        .pop-up {
+            position: absolute;
+            bottom: 0px;
+            left: 50%;
+            transform: translateX(-30%);
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            padding: 12px 16px;
+            min-width: 200px;
+            opacity: 0;
+            visibility: hidden;
+            transition:
+                opacity 0.2s,
+                visibility 0.2s;
+            z-index: 9999;
+
+            &::after {
+                content: '';
+                position: absolute;
+                bottom: -8px;
+                left: 18px;
+                width: 0;
+                height: 0;
+                border-left: 8px solid transparent;
+                border-right: 8px solid transparent;
+                border-top: 8px solid white;
+            }
+        }
+
+        &:hover {
+            .marker {
+                opacity: 0;
+                visibility: hidden;
+            }
+
+            .pop-up {
+                opacity: 1;
+                visibility: visible;
+            }
+        }
+    }
+`;
+
+export default CustomMapMarker;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useState, ReactNode } from 'react';
 import styled from 'styled-components';
 import { FaAngleLeft } from 'react-icons/fa';
-import { WIDTH } from '../utils/constants';
 
 interface SidebarProps {
     children: ReactNode;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,7 +8,7 @@ interface SidebarProps {
 }
 
 const Sidebar = ({ children }: SidebarProps) => {
-    const [isOpen, setIsOpen] = useState(true);
+    const [isOpen, setIsOpen] = useState(false);
 
     const toggleSidebar = () => {
         setIsOpen(!isOpen);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,3 +6,5 @@ export const MAP_CENTER_POSITION: Position = {
     lat: 37.49436732800421,
     lng: 127.01446798508894,
 };
+
+export const MAP_ZOOM_LEVEL = 7;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,8 @@
+import { Position } from '../components/Map';
+
 export const WIDTH = '350px';
+
+export const MAP_CENTER_POSITION: Position = {
+    lat: 37.49436732800421,
+    lng: 127.01446798508894,
+};


### PR DESCRIPTION
# 🔍 PR 개요

커스텀 마커를 만들었고 이를 이용해서 시세목록을 마커에 표시합니다

## 📝 작업 내용

<!-- 구현한 기능에 대해 자세히 작성해주세요 -->

-   [ ] 커스텀 마커를 만들었습니다. 커스텀 마커는 호버시 추가 정보를 표시합니다. 클릭시 액션은 없습니다.
-   [ ] 맵에서 마커를 표시합니다. 일단은 마커가 그리 많지 않아보여 클러스터링을 도입하지 않았습니다.
-   [ ] 기타 버그 픽스

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

-   Closes #이슈번호
-   Related to #이슈번호

## 📸 스크린샷

마커 전경
<img width="1148" alt="스크린샷 2024-11-25 오전 12 56 51" src="https://github.com/user-attachments/assets/2323f855-61b1-41c1-8aab-4050987458d2">


마커 호버전
<img width="285" alt="스크린샷 2024-11-25 오전 12 49 17" src="https://github.com/user-attachments/assets/31276885-e7e4-4a00-9735-c75878e5942f">

마커 호버후 
<img width="287" alt="스크린샷 2024-11-25 오전 12 49 20" src="https://github.com/user-attachments/assets/d096b20e-86a7-416c-8c40-906a35ae818f">


## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

-   [ ] 수동 테스트 완료
-   [ ] 불필요한 코드 없음 (console.log, 주석 등)
-   [ ] 명확한 커밋 메세지
-   [ ] 충분한 문서화

## 🔄 공유해야할 사항

- 마커 클릭시 어떻게 디테일 창을 띄울지? 서치파람? 상태공유 라이브러리?

- 현재 시작시 줌레벨보다 멀어지면 마커를 표시하지 않습니다. 마커의 크기가 고정이여서 줌이 멀어지면 다 겹쳐서 가시성이 안좋습니다.
마커의 크기를 줌레벨에 따라 다르게 할 수 도있겠지만 그거보다는 멀어지면 클러스터링을 하는편이 좋아보입니다.

- 현재 마커는 임시상태입니다. 월세 전세 필터를 구현된 다음에 발전시켜보겠습니다.



