### PR TITLE
디테일리스트 정상적으로 오픈 안되는 오류 수정

### DIFF
--- a/src/components/CategoryBar.tsx
+++ b/src/components/CategoryBar.tsx
@@ -6,6 +6,7 @@ import { MdApartment } from 'react-icons/md';
 import { CiBookmark } from 'react-icons/ci';
 import { useSise } from '../hooks/useSise';
 import { useLocation } from 'react-router-dom';
+import { CATEGORY_BAR_WIDTH } from '../utils/constants';
 
 interface ICategory {
     name: string;
@@ -54,7 +55,7 @@ const CategoryBar = () => {
 const StyledCategoryBar = styled.nav`
     display: flex;
     flex-direction: column;
-    width: 5rem;
+    width: ${CATEGORY_BAR_WIDTH};
     min-height: 100vh;
     padding-left: 0.2rem;
     padding-right: 0.2rem;

--- a/src/components/Detail/DetailList.tsx
+++ b/src/components/Detail/DetailList.tsx
@@ -46,7 +46,7 @@ const DELAY = 500;
 const stairs = [0, 350, 780, 830];
 
 const DetailList = ({ house, closeDetail }: Props) => {
-    const position = { lat: house.x, lng: house.y };
+    const position = { lat: house.y, lng: house.x };
     const [activeMenu, setActiveMenu] = useState<string>('header');
     const [bookmarkIndex, setBookMarkIndex] = useState<number>(-1);
     const [menuVisible, setMenuVisible] = useState(false);
@@ -87,7 +87,6 @@ const DetailList = ({ house, closeDetail }: Props) => {
     const handleMenuVisible = useCallback(
         throttle(() => {
             const scrollY = wrapper!.current!.scrollTop;
-            console.log(scrollY);
 
             if (scrollY >= stairs[3]) {
                 setActiveMenu(menus[3].data_link);

--- a/src/components/Detail/DetailList.tsx
+++ b/src/components/Detail/DetailList.tsx
@@ -261,7 +261,9 @@ const DetailListStyle = styled.div<DetailListStyleProps>`
     .menu {
         position: fixed;
         left: 360px;
+        top: 0;
         margin: 0;
+
         width: ${WIDTH};
         height: 40px;
         padding: 0;

--- a/src/components/Detail/DetailNeighbor.tsx
+++ b/src/components/Detail/DetailNeighbor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import { Position } from './DetailList';
 import { FaSadCry } from 'react-icons/fa';
+import ErrorBox from '../common/ErrorBox';
 
 interface Props {
     position: Position;
@@ -253,10 +254,10 @@ const DetailNeighbor = ({ position }: Props) => {
             <h2>주변 시설</h2>
             {position.lat === -1 ? (
                 <>
-                    <ErrorMap></ErrorMap>
-                    <DetailEmpty className="empty">
-                        <FaSadCry /> <span>위치를 찾을 수 없습니다</span>
-                    </DetailEmpty>
+                    <ErrorBox
+                        message="주변 정보 검색에 실패했습니다"
+                        height={300}
+                    />
                 </>
             ) : (
                 <>

--- a/src/components/Detail/DetailRoadView.tsx
+++ b/src/components/Detail/DetailRoadView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Position } from './DetailList';
-import { FaSadCry } from 'react-icons/fa';
+import ErrorBox from '../common/ErrorBox';
 
 interface Props {
     position: Position;
@@ -30,9 +30,10 @@ const DetailRoadView = ({ position }: Props) => {
 
     if (!hasRoadView) {
         return (
-            <Empty>
-                <FaSadCry /> 로드뷰가 제공되지 않는 곳입니다
-            </Empty>
+            <ErrorBox
+                message="로드뷰가 제공되지 않는 지역입니다"
+                height={200}
+            />
         );
     }
 
@@ -45,14 +46,4 @@ const DetailRoadViewStyle = styled.div`
     height: 200px;
 `;
 
-const Empty = styled.div`
-    width: 100%;
-    height: 200px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 10px;
-    background: ${({ theme }) => theme.colors.border};
-`;
 export default DetailRoadView;

--- a/src/components/SideBarItem.tsx
+++ b/src/components/SideBarItem.tsx
@@ -1,33 +1,44 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Sise } from '../models/Sise.model';
+import { SiseOfBuildingWithXy } from '../models/Sise.model';
+import ErrorBox from './common/ErrorBox';
 
 interface Props {
-    house: Sise;
+    house: SiseOfBuildingWithXy;
     index?: number;
-    onClick: (house: Sise) => void;
+    onClick: (house: SiseOfBuildingWithXy) => void;
 }
 
 const SideBarItem = ({ house, index, onClick }: Props) => {
+    const [imageError, setImageError] = useState(false);
     const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
         e.preventDefault();
         onClick(house);
     };
     return (
         <SideBarItemStyle onClick={handleClick}>
-            <img
-                src={`https://picsum.photos/id/${index}/100/100`}
-                alt={house.mhouseNm}
-            />
+            {imageError ? (
+                <ErrorBox
+                    message="이미지 로드에 실패했습니다"
+                    height={100}
+                    width={100}
+                />
+            ) : (
+                <img
+                    src={`https://picsum.photos/id/${index}/100/100`}
+                    alt={house.mhouseNm}
+                    onError={() => setImageError(true)}
+                />
+            )}
 
             <div className="content">
                 <h3>
-                    {house.monthlyRent === 0
-                        ? `전세 ${house.deposit}`
-                        : `월세 ${house.deposit}/${house.monthlyRent}`}
+                    {house.contracts[0].monthlyRent === 0
+                        ? `전세 ${house.contracts[0].deposit}`
+                        : `월세 ${house.contracts[0].deposit}/${house.contracts[0].monthlyRent}`}
                 </h3>
                 <span>{house.mhouseNm}</span>
-                <span>{house.houseType}</span>
+                <span>{house.huseType}</span>
             </div>
         </SideBarItemStyle>
     );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,16 +1,18 @@
 import { useState, ReactNode } from 'react';
 import styled from 'styled-components';
 import { FaAngleLeft } from 'react-icons/fa';
+import { CATEGORY_BAR_WIDTH, WIDTH } from '../utils/constants';
 
 interface SidebarProps {
     children: ReactNode;
 }
 
 const Sidebar = ({ children }: SidebarProps) => {
-    const [isOpen, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     const toggleSidebar = () => {
         setIsOpen(!isOpen);
+        console.log(isOpen);
     };
 
     return (
@@ -58,7 +60,10 @@ const ToggleButton = styled.button<ToggleButtonProps>`
     align-items: center;
     justify-content: center;
     top: 50%;
-    left: ${({ $isOpen }) => ($isOpen ? '411px' : '79px')};
+    left: ${({ $isOpen }) =>
+        $isOpen
+            ? `calc(${WIDTH} +  ${CATEGORY_BAR_WIDTH})`
+            : ` ${CATEGORY_BAR_WIDTH}`};
     z-index: 1000;
     width: 23px;
     height: 46px;

--- a/src/components/SiseList2.tsx
+++ b/src/components/SiseList2.tsx
@@ -1,19 +1,21 @@
-import { useSise } from '../hooks/useSise';
 import SideBarItem from './SideBarItem';
 import styled from 'styled-components';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Sise } from '../models/Sise.model';
+import { SiseOfBuildingWithXy } from '../models/Sise.model';
 import DetailList from './Detail/DetailList';
+import useSiseWithReactQuery from '../hooks/useSiseWithReactQuery';
+import { WIDTH } from '../utils/constants';
+import LoadingSpinner from './common/LoadingSpinner';
 
 const SiseList2 = () => {
-    const { siseData } = useSise();
+    const { data, isLoading } = useSiseWithReactQuery();
     const [searchParams, setSearchParams] = useSearchParams();
-    const [detailInfo, setDetailInfo] = useState<Sise | null>();
+    const [detailInfo, setDetailInfo] = useState<SiseOfBuildingWithXy | null>();
 
     const detailId = searchParams.get('detail_id');
 
-    const openDetail = (house: Sise) => {
+    const openDetail = (house: SiseOfBuildingWithXy) => {
         const newSearchParams = new URLSearchParams(searchParams.toString());
         newSearchParams.set('detail_id', 'open');
         setSearchParams(newSearchParams);
@@ -26,14 +28,19 @@ const SiseList2 = () => {
     };
     return (
         <StyledSiseList2>
-            {siseData.map((house, index) => (
-                <SideBarItem
-                    house={house}
-                    index={index}
-                    key={index}
-                    onClick={openDetail}
-                />
-            ))}
+            {isLoading ? (
+                <LoadingSpinner />
+            ) : (
+                data?.map((house, index) => (
+                    <SideBarItem
+                        key={house.jibun + house.mhouseNm}
+                        house={house}
+                        index={index}
+                        onClick={() => openDetail(house)}
+                    />
+                ))
+            )}
+
             {detailId && detailInfo && (
                 <DetailList house={detailInfo} closeDetail={closeDetail} />
             )}
@@ -41,27 +48,11 @@ const SiseList2 = () => {
     );
 };
 
-// 현재는 네이버 지도처럼 팝업으로 띄우는 레이아웃으로 해보았습니다. (하드코딩되는 부분없이 비율로만 조정해보려고 했는데 어려운 부분이 있네요)
-// 다방처럼 사이드바가 늘어나면서 상세정보가 나오게 하고 싶다면
-// 아래와 같이 변경하고 이 컴포넌트와 DetailList 컴포넌트 스타일을 조정하면 가능합니다.
-
-{
-    /* <현재컴포넌트 style={
-    display: flex;
-    flex-direction: row;
-    height: 100%;
-    width: 100%;
-}>
-    <시세 목록 컴포넌트/>
-    <상세정보 컴포넌트/>
-</현재컴포넌트> */
-}
-
 const StyledSiseList2 = styled.div`
     display: flex;
     flex-direction: column;
     height: 100%;
-    width: 330px;
+    width: ${WIDTH};
     overflow-y: scroll;
 `;
 

--- a/src/components/common/ErrorBox.tsx
+++ b/src/components/common/ErrorBox.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { FaSadCry } from 'react-icons/fa';
+import styled from 'styled-components';
+
+interface Props {
+    width?: number;
+    height?: number;
+    message: string;
+}
+const ErrorBox = ({ height, message, width }: Props) => {
+    return (
+        <ErrorBoxStyle height={height} width={width}>
+            <FaSadCry />
+            <span>{message}</span>
+        </ErrorBoxStyle>
+    );
+};
+
+interface ErrorBoxStyleProps {
+    height?: number;
+    width?: number;
+}
+const ErrorBoxStyle = styled.div<ErrorBoxStyleProps>`
+    width: 100%;
+    height: ${({ height }) => (height ? `${height}px` : '100%')};
+    width: ${({ width }) => (width ? `${width}px` : '100%')};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    background: ${({ theme }) => theme.colors.border};
+
+    span {
+        text-align: center;
+    }
+`;
+export default ErrorBox;

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FaSpinner } from 'react-icons/fa';
+import styled from 'styled-components';
+
+const LoadingSpinner = () => {
+    return (
+        <LoadingSpinnerStyle>
+            <FaSpinner className="spinner" />
+        </LoadingSpinnerStyle>
+    );
+};
+const LoadingSpinnerStyle = styled.div`
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    @keyframes spin {
+        from {
+            transform: rotate(0deg);
+        }
+        to {
+            transform: rotate(360deg);
+        }
+    }
+
+    .spinner {
+        animation: spin 1s linear infinite;
+        fill: 'orange';
+    }
+`;
+export default LoadingSpinner;

--- a/src/hooks/useSiseWithReactQuery.ts
+++ b/src/hooks/useSiseWithReactQuery.ts
@@ -65,7 +65,7 @@ const useSiseWithReactQuery = () => {
         }
     }, [data, isFetching, isLoading, regionCode, dataUpdatedAt]);
 
-    return { data, isPending, isError, error };
+    return { data, isPending, isError, error, isLoading };
 };
 
 export default useSiseWithReactQuery;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import { Position } from '../components/Map';
 
 export const WIDTH = '350px';
+export const CATEGORY_BAR_WIDTH = '5rem';
 
 export const MAP_CENTER_POSITION: Position = {
     lat: 37.49436732800421,


### PR DESCRIPTION
# 🔍 PR 개요

디테일리스트 정상적으로 오픈 안되는 오류 수정

## 📝 작업 내용

-   [ ] 디테일 리스트 정상적으로 오픈되게 수정
-   [ ] useSiseWithReactQuery를 통해 데이터 전달 받음
-  [ ] 로딩 상태를 나타내는 LoadingSpinner와 데이터를 못 받아올 때 나타나는 ErrorBox 컴포넌트 추가
-  [ ] 주변 시설 지도 정상적으로 표시 안 되는 버그 수정

## 🔗 관련 이슈

#25 

## 📸 스크린샷

스피너 추가
<img width="1440" alt="스크린샷 2024-11-25 오후 3 38 53" src="https://github.com/user-attachments/assets/f2f8466f-512b-4d23-b336-e6eaa8165d9b">

디테일 리스트 오픈 및 주변 시설 지도 오류 수정

<img width="781" alt="스크린샷 2024-11-25 오후 3 47 31" src="https://github.com/user-attachments/assets/e504b484-bfc9-4418-89e0-b3b53d92cbb5">


### Before

<!-- 변경 전 스크린샷 -->

### After

<!-- 변경 후 스크린샷 -->

## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

-   [ x ] 수동 테스트 완료
-   [ ] 불필요한 코드 없음 (console.log, 주석 등)
-   [ ] 명확한 커밋 메세지
-   [ ] 충분한 문서화

## 🔄 변경 로직 설명
- [ ] 디테일리스트의 position을 absolute에서 fixed로 변경
- [ ] useSise에서 useSiseWithReactQuery 로 데이터 fetch 함수 변경
- [ ] 로딩 상태 파악을 위해 useSiseWithReactQuery에 isLoading 추가

```js
// 예시 코드나 설명
```
