### PR TITLE
디테일 리스트 렌더링 오류 수정 및 커스텀 오버레이 추가

### DIFF
--- a/src/components/Detail/DetailList.tsx
+++ b/src/components/Detail/DetailList.tsx
@@ -178,7 +178,7 @@ const DetailList = ({ closeDetail }: Props) => {
                     </div>
                 </div>
                 <div className="detail_content">
-                    <DetailRoadView position={position} />
+                    <DetailRoadView />
 
                     <h2>
                         {detailInfo!.contracts[0].monthlyRent === 0
@@ -204,7 +204,7 @@ const DetailList = ({ closeDetail }: Props) => {
                 </div>
 
                 <div className="detail_neighbor">
-                    <DetailNeighbor position={position} />
+                    <DetailNeighbor />
                 </div>
 
                 <div className="detail_graph">

--- a/src/components/Detail/DetailRoadView.tsx
+++ b/src/components/Detail/DetailRoadView.tsx
@@ -1,22 +1,19 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import ErrorBox from '../common/ErrorBox';
-import { Position } from '../Map';
+import { useTypedSelector } from '../../hooks/redux';
 
-interface Props {
-    position: Position;
-}
-
-const DetailRoadView = ({ position }: Props) => {
+const DetailRoadView = () => {
+    const { detailInfo } = useTypedSelector((state) => state.detail);
     const [hasRoadView, setHasRoadView] = useState(true);
     const roadviewContainerRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        if (!roadviewContainerRef.current) return;
+        if (!roadviewContainerRef.current || !detailInfo) return;
 
         const roadview = new kakao.maps.Roadview(roadviewContainerRef.current);
         const roadviewClient = new kakao.maps.RoadviewClient();
-        const kakaoPosition = new kakao.maps.LatLng(position.lat, position.lng);
+        const kakaoPosition = new kakao.maps.LatLng(detailInfo.y, detailInfo.x);
 
         roadviewClient.getNearestPanoId(kakaoPosition, 50, (panoId) => {
             if (panoId === null) {
@@ -24,9 +21,20 @@ const DetailRoadView = ({ position }: Props) => {
             } else {
                 setHasRoadView(true);
                 roadview.setPanoId(panoId, kakaoPosition);
+
+                const marker = new kakao.maps.Marker({
+                    position: kakaoPosition,
+                    map: roadview, // 로드뷰에 마커를 추가
+                });
+
+                // 정보창 생성 및 마커에 연결
+                const infoWindow = new kakao.maps.InfoWindow({
+                    content: `<div style="padding:5px;"><span>${detailInfo.mhouseNm}</span></div>`,
+                });
+                infoWindow.open(roadview, marker);
             }
         });
-    }, [position]);
+    }, [detailInfo, roadviewContainerRef]);
 
     if (!hasRoadView) {
         return (
@@ -37,10 +45,9 @@ const DetailRoadView = ({ position }: Props) => {
         );
     }
 
-    return (
-        <DetailRoadViewStyle ref={roadviewContainerRef} className="roadview" />
-    );
+    return <DetailRoadViewStyle ref={roadviewContainerRef} />;
 };
+
 const DetailRoadViewStyle = styled.div`
     width: 100%;
     height: 200px;

--- a/src/components/SiseList.tsx
+++ b/src/components/SiseList.tsx
@@ -19,8 +19,8 @@ const SiseList = ({ isCompareMode, onCompareComplete }: SiseListProps) => {
     const [compareData, setCompareData] = useState<SiseOfBuilding[]>([]);
 
     const openDetail = (house: SiseOfBuildingWithXy) => {
-        dispatch(setDetail(house));
         dispatch(setDetailOpen(true));
+        dispatch(setDetail(house));
     };
 
     const closeDetail = () => {


### PR DESCRIPTION
# 🔍 PR 개요

디테일 리스트의 로드뷰와 주변 시설 렌더링 오류가 수정되었습니다

로드뷰에 현재 보고 있는 건물의 마커가 표시되며, 주변 시설에서 마커를 클릭하면 해당 시설의 이름과 거리가 표시됩니다

## 📝 작업 내용

<!-- 구현한 기능에 대해 자세히 작성해주세요 -->

-   [x] 로드뷰와 주변 시설 컴포넌트가 리덕스를 통해 각각 detail 정보를 받아옴
-   [x] 로드뷰 건물 마커 표시
-   [x] 주변 시설 커스텀 오버레이 추가

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

-   Closes #이슈번호
-   Related to #35 

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="333" alt="스크린샷 2024-11-27 오전 12 26 43" src="https://github.com/user-attachments/assets/6dfb998f-e9fc-46ae-8098-52d4d99680e6">

<img width="341" alt="스크린샷 2024-11-27 오전 12 26 52" src="https://github.com/user-attachments/assets/4ecf29ec-3de2-4068-aa0d-091523b1c731">

### Before

<!-- 변경 전 스크린샷 -->

### After

<!-- 변경 후 스크린샷 -->

## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

-   [ ] 수동 테스트 완료
-   [ ] 불필요한 코드 없음 (console.log, 주석 등)
-   [ ] 명확한 커밋 메세지
-   [ ] 충분한 문서화

## 🔄 변경 로직 설명

<!-- 주요 로직 변경사항을 설명해주세요 -->

로드뷰와 주변 시설 컴포넌트가 리덕스를 통해 각각 detail 정보를 받아옵니다
사이드리스트가 새로 랜더링 되어도 디테일리스트는 새로 랜더링 되지 않습니다

```js
const DetailNeighbor = () => {
    const { detailInfo } = useTypedSelector((state) => state.detail);
```

